### PR TITLE
FIX: Add brush to final plot on measles notebook

### DIFF
--- a/notebooks/12-Measles.ipynb
+++ b/notebooks/12-Measles.ipynb
@@ -39568,19 +39568,19568 @@
    "metadata": {},
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'brush' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-8-46ad51452085>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m     27\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     28\u001b[0m text = alt.Chart().mark_text(align='right').encode(\n\u001b[0;32m---> 29\u001b[0;31m     \u001b[0mx\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0malt\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mX\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'min(YEAR):Q'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mscale\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0malt\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mScale\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdomain\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mbrush\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mref\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     30\u001b[0m     \u001b[0my\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'mean(incidence):Q'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     31\u001b[0m     \u001b[0mtext\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'state:N'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'brush' is not defined"
-     ]
+     "data": {
+      "application/vnd.vegalite.v2+json": {
+       "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+       "config": {
+        "view": {
+         "height": 300,
+         "width": 400
+        }
+       },
+       "data": {
+        "values": [
+         {
+          "YEAR": 1928,
+          "incidence": 334.98999999999995,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 111.93000000000004,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 157.00000000000006,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 337.29000000000013,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 10.20999999999999,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 65.21999999999998,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 590.27,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 265.3400000000002,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 20.779999999999994,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 22.459999999999987,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 496.4400000000001,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 182.63999999999984,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 115.12000000000002,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 297.47000000000014,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 126.14999999999995,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 130.82000000000002,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 252.86999999999998,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 27.329999999999984,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 126.74999999999997,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 127.25999999999995,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 69.09000000000002,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 368.79999999999984,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 50.900000000000006,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 103.24000000000002,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 351.71999999999997,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 93.99000000000001,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 280.3899999999998,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 69.68,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 231.74999999999994,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 299.78999999999996,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 242.33999999999992,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 108.19000000000003,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 63.330000000000005,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 78.01000000000002,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 71.58000000000006,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 34.74000000000002,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 533.6800000000001,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 68.20000000000006,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 52.37999999999999,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 38.98000000000002,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 4.650000000000001,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 0.36,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 13.94,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 55.24000000000001,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 4.02,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 0.42000000000000004,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 0.58,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 0.13,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 0,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 2.06,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 3.43,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 3.35,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 0.5700000000000001,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.05,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.03,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.02,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0.09000000000000001,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0.02,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 1.4600000000000002,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 0.6500000000000001,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.02,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0.02,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.14,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0.16,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "ALABAMA"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 691.67,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 241.86999999999998,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 1120.98,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 414.70000000000005,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 562.0600000000002,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 816.5500000000001,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 635.7899999999997,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 420.96000000000004,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 571.5400000000001,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 722.27,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 439.8899999999997,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 79.38,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 236.57,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 53.269999999999975,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 3.8600000000000003,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 6.77,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 33.61000000000001,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 19.419999999999995,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 3.9399999999999995,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 1.47,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 0.27,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 2.73,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 15.07,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 0.5,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 4.48,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 1.44,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.2,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0.18,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 4.859999999999999,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.18,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.68,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 2.67,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 11.160000000000002,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.16,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 2.58,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0.16,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "ALASKA"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 200.75000000000003,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 54.87999999999996,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 466.30999999999983,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 497.6900000000003,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 20.110000000000003,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 296.0100000000002,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 238.8099999999999,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 135.01999999999995,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 525.5,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 837.3000000000002,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 149.34000000000006,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 144.02,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 339.05999999999995,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 615.2899999999997,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 740.8300000000003,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 172.43999999999997,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 736.7099999999999,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 93.74000000000002,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 498.69000000000005,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 224.49000000000015,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 623.3799999999999,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 531.4599999999997,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 315.95000000000005,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 1351.4900000000007,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 424.58999999999986,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 557.9100000000001,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 531.51,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 1024.03,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 644.3200000000003,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 700.9700000000003,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 825.1799999999997,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 719.0200000000002,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 325.9099999999999,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 559.22,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 431.74000000000007,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 583.67,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 405.53999999999985,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 100.59999999999995,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 336.90000000000003,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 62.080000000000005,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 14.61,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 31.210000000000004,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 53.049999999999976,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 25.390000000000004,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 40.83000000000002,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 1.12,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 0.8900000000000002,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 3.53,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 9.999999999999995,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 8.71,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 2.52,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 3.2499999999999996,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 11.629999999999999,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.36000000000000004,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.53,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 7.49,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 7.450000000000001,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 1,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0.08,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 3.9600000000000004,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 7.720000000000001,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 9.040000000000001,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0.06,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.2,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0.26999999999999996,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.16999999999999998,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.18,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0.2,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0.02,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0.02,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "ARIZONA"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 481.7700000000002,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 67.21999999999996,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 53.43999999999998,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 45.910000000000004,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 5.329999999999997,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 293.31999999999994,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 384.57,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 80.32999999999998,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 5.66,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 16.980000000000004,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 356.7299999999999,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 123.51000000000003,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 72,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 273.88999999999993,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 232.69999999999996,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 162.60000000000008,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 207.51,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 69.50000000000001,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 168.4699999999999,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 130.60999999999996,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 208.30000000000007,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 667.7199999999998,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 91.11999999999995,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 401.0900000000001,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 188.5500000000001,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 727.4099999999999,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 151.02999999999997,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 173.5399999999999,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 506.8599999999999,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 78.41000000000003,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 173.95,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 46.49,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 89.24000000000004,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 93.25999999999999,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 77.60999999999999,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 77.49999999999999,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 58.27999999999999,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 63.07999999999996,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 72.49,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 66.75999999999998,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 0.15000000000000002,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 1.5100000000000002,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 1.6600000000000001,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 21.910000000000007,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 0.65,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 3.709999999999999,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 0.66,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 0.1,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 0.91,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 2.04,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 0.9600000000000001,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 0.4699999999999999,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 0.7600000000000001,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.5900000000000001,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.04,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0.38,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 12.209999999999999,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 0.21000000000000002,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 1.7399999999999998,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0.08,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.12,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0.16,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0.04,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "ARKANSAS"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 69.22,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 72.8,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 760.2399999999997,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 477.4800000000002,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 214.07999999999998,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 445.2800000000002,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 423.2599999999999,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 466.38000000000005,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 773.5399999999998,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 78.25999999999999,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 278.32,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 939.4799999999998,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 376.4400000000001,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 174.41999999999996,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 1222.0099999999995,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 340.06,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 599.9699999999999,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 339.44000000000005,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 575.1599999999999,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 74.97999999999995,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 487.91,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 320.8200000000001,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 137.92000000000002,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 548.36,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 335.25000000000006,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 438.9099999999999,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 473.0500000000002,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 513.4599999999999,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 235.20999999999998,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 353.3500000000001,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 235.7199999999999,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 251.82000000000002,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 140.03000000000003,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 223.41999999999996,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 164.86000000000004,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 113.36,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 179.89999999999992,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 74.60000000000005,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 80.58999999999997,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 27.449999999999992,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 8.49,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 4.569999999999998,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 9.550000000000004,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 13.88,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 15.429999999999996,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 3.8199999999999994,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 5.139999999999998,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 23.779999999999994,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 10.410000000000002,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 34.75000000000001,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 2.8099999999999987,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 4.079999999999998,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 3.649999999999999,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 1.4000000000000006,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 3.1599999999999993,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.5900000000000002,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 1.2000000000000004,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0.9200000000000004,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 1.5200000000000005,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 2.679999999999999,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 2.480000000000001,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 7.339999999999999,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 31.99,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 6.4899999999999975,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.19000000000000003,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0.18000000000000002,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.19000000000000003,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0.09,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.10999999999999999,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.09,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0.060000000000000005,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0.03,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0.11000000000000001,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "CALIFORNIA"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 206.97999999999996,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 74.24,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 1132.7600000000007,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 453.26999999999975,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 222.89999999999992,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 27.690000000000005,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 1204.2500000000002,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 1186.0699999999995,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 54.74,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 93.00000000000001,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 823.7099999999998,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 525.2100000000002,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 231.80000000000007,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 661.7499999999999,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 505.49000000000007,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 976.9699999999999,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 556.4900000000002,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 95.91000000000001,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 992.7400000000004,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 142.93,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 723.2800000000001,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 557.6100000000001,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 395.37000000000006,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 934.0200000000001,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 386.91999999999996,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 684.0000000000001,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 127.66,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 317.08,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 873.2199999999993,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 173.46999999999994,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 566.1099999999998,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 411.5000000000001,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 384.7299999999998,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 210.35000000000005,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 473.99999999999994,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 325.28000000000003,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 164.42999999999995,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 302.7000000000003,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 72,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 79.64,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 23.540000000000006,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 6.429999999999999,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 10.409999999999998,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 37.16999999999998,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 20.879999999999978,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 6.550000000000001,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 6.13,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 44.43999999999999,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 16.67,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 15.699999999999994,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 1.8,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 2.479999999999999,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 0.7700000000000001,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.25,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.22,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0.27,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.15,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0.27,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 3.5299999999999994,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 3.0199999999999996,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 4.170000000000001,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.32999999999999996,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.6400000000000001,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.54,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0.6799999999999999,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.21,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.72,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0.06,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "COLORADO"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 634.9500000000002,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 614.82,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 112.22999999999999,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 790.4599999999996,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 348.27000000000027,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 330.6600000000002,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 282.34999999999997,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 1449.4899999999996,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 228.97,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 606.7599999999994,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 107.55999999999999,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 937.5399999999997,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 376.52000000000015,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 364.5700000000001,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 587.8799999999999,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 550.3800000000001,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 493.49999999999983,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 170.20000000000005,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 397.9099999999999,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 814.9199999999998,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 140.62000000000006,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 935.63,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 197.44999999999996,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 227.42999999999992,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 1179.01,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 99.99000000000002,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 223.47000000000003,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 1256.63,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 116.46000000000004,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 409.9900000000001,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 645.6500000000001,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 516.4599999999998,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 434.6199999999999,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 261.76,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 672.06,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 214.81000000000003,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 189.03000000000006,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 322.89000000000004,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 32.51000000000002,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 3.569999999999998,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 23.820000000000004,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 21.390000000000004,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 3.819999999999998,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 38.910000000000025,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 50.080000000000005,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 59.170000000000016,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 5.6,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 4.159999999999999,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 7.640000000000001,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 25.020000000000003,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 17.039999999999996,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 0.12,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 0.8500000000000001,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.27,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.24,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0.31000000000000005,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0.18,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.27,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0.66,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0.51,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 6.529999999999999,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 5.7,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.6900000000000001,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.06,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0.18,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.12,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0.03,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.03,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "CONNECTICUT"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 256.02000000000004,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 239.81999999999988,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 109.25000000000007,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 1003.2799999999999,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 15.980000000000004,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 82.68000000000004,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 1225.2000000000005,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 412.70000000000005,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 555.9599999999998,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 707.0999999999997,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 236.0199999999999,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 94.63000000000001,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 36.040000000000006,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 1268.3499999999992,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 90.16000000000004,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 564.55,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 138.39999999999998,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 96.85999999999996,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 198.98000000000005,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 19.409999999999997,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 333.1299999999998,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 234.52999999999986,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 194.70000000000013,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 208.42000000000007,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 119.34000000000002,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 115.87999999999997,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 527.67,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 26.98000000000002,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 212.31000000000003,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 78.13000000000002,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 118.89999999999998,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 139.7,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 212.92000000000004,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 368.3500000000002,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 129.41999999999993,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 248.69000000000005,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 79.25999999999999,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 102.38000000000005,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 51.139999999999986,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 10.64,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 4.51,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 93.72999999999998,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 47.46000000000001,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 7.269999999999998,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 9.66,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 1.71,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 2.7199999999999998,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 5.939999999999999,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 18.799999999999997,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 1.18,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 1.8699999999999999,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 0.17,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 0.68,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.16,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 3.09,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 5.4,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 1.3499999999999999,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 2.809999999999999,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.42000000000000004,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0.28,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.13,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "DELAWARE"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 535.6300000000001,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 94.19999999999993,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 182.10000000000002,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 832.9900000000005,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 53.13999999999998,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 100.79999999999995,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 1137.4900000000005,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 152.73000000000002,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 335.5900000000001,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 333.2700000000003,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 115.58999999999995,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 497.41999999999996,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 126.9900000000001,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 488.18999999999994,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 190.76000000000002,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 234.27000000000004,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 310.09000000000015,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 39.58999999999999,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 465.9200000000002,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 60.150000000000006,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 305.04999999999995,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 278.56000000000006,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 213.51000000000005,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 185.16000000000003,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 286.1700000000001,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 44.04999999999997,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 383.2999999999999,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 57.68999999999999,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 210.27999999999986,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 114.82000000000005,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 187.56999999999996,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 52.169999999999995,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 158.16,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 47.09000000000001,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 89.19999999999996,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 27.759999999999994,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 43.14000000000003,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 19.760000000000005,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 49.30000000000003,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 3.459999999999999,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 0.78,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 5.89,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 46.000000000000036,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 2.1199999999999997,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 0.27,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 1.4000000000000004,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 0.14,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 0.28,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 1.94,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 2.1,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 0.3,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 0.16,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 0.79,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.32,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.16,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 4.390000000000001,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 6.74,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 3.6599999999999997,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.33,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.35,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "DISTRICT OF COLUMBIA"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 119.57999999999998,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 78.00999999999996,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 356.58999999999975,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 260.79,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 13.63000000000001,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 63.930000000000014,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 505.65,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 72.77000000000005,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 18.22,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 23.080000000000002,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 517.8299999999998,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 157.53,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 114.18999999999994,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 459.75999999999993,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 189.61000000000004,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 68.56999999999998,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 189.74,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 39.62999999999998,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 116.89,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 53.099999999999994,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 152.39000000000004,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 144.02999999999997,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 83.42999999999998,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 76.20999999999998,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 109.98999999999997,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 38.5,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 312.2699999999998,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 38.040000000000006,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 127.23000000000002,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 120.36000000000001,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 266.67000000000013,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 74.68000000000002,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 74.45999999999998,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 127.69000000000001,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 76.09000000000002,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 66.69000000000003,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 121.54999999999997,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 62.29,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 64.38000000000001,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 28.919999999999998,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 8.939999999999998,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 9.269999999999994,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 20.189999999999987,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 30.830000000000013,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 17.63999999999999,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 4.6999999999999975,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 2.699999999999999,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 0.9400000000000001,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 3.7799999999999994,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 3.2999999999999985,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 11.6,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 6.199999999999996,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 4.039999999999998,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 2.8899999999999983,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 2.01,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 1.4800000000000004,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0.16000000000000003,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0.9900000000000002,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 3.3800000000000003,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0.7200000000000002,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 1.3200000000000003,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 1.6,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 2.8699999999999983,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 2.2100000000000004,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.3000000000000001,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0.20000000000000004,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.16,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0.060000000000000005,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.060000000000000005,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0.01,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0.01,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0.02,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0.01,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "FLORIDA"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 159.73,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 40.63,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 153.20999999999995,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 104.38999999999993,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 34.360000000000014,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 156.88,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 774.7800000000002,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 1.05,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 0.27,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 0,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 299.9200000000001,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 115.95,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 93.83999999999995,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 294.1200000000003,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 168.74,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 126.45,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 171.50999999999996,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 27.53000000000001,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 117.11000000000001,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 102.39000000000007,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 37.80000000000001,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 288.6999999999999,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 62.420000000000016,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 213.03000000000003,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 225.42000000000007,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 86.49000000000005,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 188.04000000000013,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 68.17999999999996,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 128.9,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 155.66000000000008,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 175.17999999999998,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 11.539999999999997,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 5.5299999999999985,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 10.240000000000002,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 10.190000000000001,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 4.779999999999999,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 4.919999999999997,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 15.1,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 5.589999999999997,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 0.9600000000000004,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 0.08,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 0.04,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 0.36,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 23.590000000000003,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 3.5600000000000014,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 1.0200000000000002,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 0.06,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 0.78,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 0.1,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 14.409999999999997,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 1.06,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 10.139999999999999,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 15.19,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 1.9500000000000004,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.14,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0.06,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0.13,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 1.4900000000000002,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0.15,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 0.27,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 5.5,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.22999999999999998,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.04,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0.01,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.03,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0.060000000000000005,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.01,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0.01,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0.01,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0.01,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "GEORGIA"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 13.22,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 955.2399999999999,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 99.86,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 1186.4400000000003,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 922.02,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 866.2399999999994,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 95.07999999999994,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 592.6,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 828.9999999999994,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 29.62,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 387.28999999999996,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 521.8300000000003,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 123.18000000000002,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 575.8,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 20.360000000000007,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 24.460000000000004,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 5.05,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 7.02,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 23.860000000000014,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 59.03,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 11.239999999999997,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 3.5200000000000005,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 7.100000000000002,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 7.170000000000002,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 1.2,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 4.7299999999999995,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 2.17,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 7.949999999999995,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 0.8999999999999999,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.8,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.5,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.1,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 16.64,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 2.3300000000000005,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 2.7800000000000002,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0.18,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 1.81,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 2.7899999999999996,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 3.69,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 1.9500000000000004,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 4.239999999999999,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 1.3,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 2.8100000000000005,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.49000000000000005,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0.08,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0.16,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0.57,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0.08,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "HAWAII"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 19.590000000000003,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 160.37,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 196.65999999999988,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 25.969999999999995,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 8.760000000000002,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 193.59000000000006,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 252.43000000000004,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 182.32999999999998,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 262.6199999999999,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 243.1499999999999,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 425.67,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 694.1499999999999,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 337.5299999999999,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 102.03000000000003,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 395.08000000000004,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 650.9000000000003,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 182.33999999999995,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 259.93,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 433.5999999999999,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 51.13000000000001,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 275.2,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 511.03,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 324.05000000000007,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 358.07000000000005,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 196.07,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 324.34000000000003,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 734.1699999999998,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 113.75999999999993,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 317.56000000000006,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 486.9,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 591.94,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 247.20000000000013,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 421.9199999999999,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 281.75000000000006,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 234.11999999999992,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 572.4800000000001,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 336.1899999999999,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 454.6599999999999,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 246.92999999999998,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 60.04999999999996,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 3.0000000000000004,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 12.740000000000002,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 13.32,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 35.9,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 14.09,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 31.710000000000008,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 6.48,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 2.35,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 224.33,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 18.56,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 0.43,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 2.34,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 0,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.2,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.1,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 6.249999999999998,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.1,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 0.7999999999999999,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 2.1900000000000004,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 42.15000000000002,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.18,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0.33,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.16,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 6.59,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0.08,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0.16,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "IDAHO"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 98.23999999999997,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 506.1800000000002,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 216.06999999999996,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 516.9700000000003,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 208.31000000000003,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 155.64999999999998,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 574.84,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 746.8099999999996,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 15.430000000000001,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 146.95000000000002,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 1145.1600000000003,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 100.12000000000002,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 84.13999999999999,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 613.1400000000001,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 132.68999999999997,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 328.4500000000001,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 239.78999999999996,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 103.25,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 298.12000000000023,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 91.44999999999999,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 426.9899999999999,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 65.92,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 200.35000000000005,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 187.66000000000005,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 294.52,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 173.71,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 358.74,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 144.65,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 441.99000000000007,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 100.27000000000001,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 233.09,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 96.16,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 224.65999999999994,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 159.00000000000003,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 163.36999999999998,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 98.54999999999998,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 149.33000000000004,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 42.68000000000001,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 106.31,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 11.930000000000001,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 13.520000000000001,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 10.16,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 29.379999999999995,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 29.04,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 40.22,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 19.479999999999993,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 18.730000000000004,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 16.49,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 17.86,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 16.56,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 6.979999999999998,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 11.599999999999998,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 2.969999999999999,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.26000000000000006,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.24000000000000002,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 1.7200000000000004,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 1.3599999999999999,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 2.4299999999999997,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 3.67,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 1.7000000000000008,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0.47000000000000003,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 22.319999999999997,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 9.049999999999999,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.05,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.09,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0.04,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.15,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0.04,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.02,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.07999999999999999,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0.01,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0.04,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0.01,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "ILLINOIS"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 263.6700000000001,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 322.0999999999998,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 120.73000000000003,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 541.2099999999997,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 88.78,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 108.02000000000004,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 631.0300000000001,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 299.12,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 21.150000000000006,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 210.12000000000006,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 523.1799999999998,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 59.79000000000001,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 16.650000000000002,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 381.6299999999999,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 94.99000000000001,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 262.9999999999999,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 149.11000000000004,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 33.51,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 293.0500000000001,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 60.92999999999999,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 366.53999999999985,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 100.14000000000006,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 169.40999999999997,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 101.99999999999999,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 179.11000000000004,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 162.58,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 517.1199999999997,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 86.35999999999999,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 368.1700000000002,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 180.31000000000006,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 396.55,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 99.64,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 223.08000000000004,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 124.69,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 161.79000000000005,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 122.35999999999997,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 458.8100000000002,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 48.06,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 116.34000000000002,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 13.459999999999992,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 15.549999999999995,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 10.509999999999993,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 5.499999999999997,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 58.23000000000002,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 23.799999999999997,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 13.269999999999996,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 4.86,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 9.669999999999995,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 79.97000000000001,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 71.14999999999998,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 3.949999999999998,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 3.6699999999999995,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 2.0100000000000007,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.34,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.06,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 6.779999999999999,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0.04,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0.06,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.7000000000000001,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 1.04,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 2.02,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 4.489999999999999,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.09,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.22,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0.02,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.02,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0.03,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0.02,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0.03,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0.02,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "INDIANA"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 28.629999999999995,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 82.94999999999999,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 395.59000000000003,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 34.24999999999998,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 6.320000000000003,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 33.00999999999999,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 346.39,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 865.6500000000002,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 8.000000000000004,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 10.759999999999993,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 223.17000000000002,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 209.13,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 212.60000000000005,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 197.87000000000003,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 254.79,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 242.79999999999998,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 201.37999999999997,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 61.40000000000002,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 160.44000000000003,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 177.89000000000004,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 352.26,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 87.03,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 399.49000000000007,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 103.78000000000002,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 120.83999999999999,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 413.7799999999998,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 477.13999999999993,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 286.64000000000004,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 307.41,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 330.74999999999994,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 463.82,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 420.25000000000017,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 63.999999999999964,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 192.53000000000003,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 393.63000000000005,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 280.07000000000016,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 819.8199999999999,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 339.54,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 197.39,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 29.599999999999987,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 6.580000000000001,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 9.979999999999995,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 31.419999999999998,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 94.78999999999995,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 33.27000000000001,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 10.119999999999997,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 4.6000000000000005,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 24.110000000000007,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 1.4000000000000001,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 123.71999999999998,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 2.9599999999999995,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 0.53,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 0.06,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.03,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 5.1000000000000005,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 0.44999999999999996,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 0.9600000000000002,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.5900000000000001,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.25,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.28,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0.03,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0.06,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "IOWA"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 136.92000000000007,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 555.4399999999999,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 666.7099999999998,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 93.46999999999994,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 326.6400000000001,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 335.07999999999987,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 538.84,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 1399.01,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 23.17,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 42.11,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 583.0599999999997,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 158.20999999999998,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 450.29999999999995,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 764.47,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 535.23,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 547.8399999999998,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 551.6200000000001,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 95.98000000000002,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 658.17,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 48.12,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 58.309999999999974,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 882.31,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 93.16999999999999,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 572.1899999999997,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 326.0699999999998,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 750.8700000000001,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 66.41000000000003,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 145.55999999999997,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 200.78000000000006,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 0.6200000000000001,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 3.3200000000000003,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 0,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 0,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 0,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 0,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 0,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 0,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 0,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 0,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 4.4399999999999995,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 0.9600000000000001,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 0.38,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 3.3500000000000005,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 62.42000000000001,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 1.72,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 1.1900000000000002,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 8.25,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 93.30000000000003,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 32.17,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 61.230000000000004,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 4.499999999999999,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 3.1399999999999997,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 3.11,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.04,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 1.8199999999999998,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0.04,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 4.040000000000001,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0.04,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 4.750000000000001,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 9.46,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.36,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.08,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.04,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0.04,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.04,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0.08,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0.04,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "KANSAS"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 216.26,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 43.17,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 70.14999999999999,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 181.04000000000005,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 72.99000000000004,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 57.859999999999985,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 422.55,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 533.7700000000001,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 79.66000000000001,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 245.75000000000006,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 393.49,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 79.77999999999997,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 97.62,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 610.5000000000003,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 84.08000000000003,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 383.79,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 86.50000000000001,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 61.13,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 269.63000000000005,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 30.119999999999994,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 127.97,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 294.61000000000007,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 162.64999999999998,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 290.9599999999999,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 362.9700000000001,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 134.50999999999996,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 1026,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 76.09,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 610.2900000000002,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 557.7599999999996,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 619.6400000000002,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 221.65000000000003,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 352.98,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 368.6800000000001,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 202.28999999999988,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 284.8800000000001,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 481.84000000000015,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 121.06000000000002,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 154.20999999999992,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 46.83000000000002,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 4.369999999999999,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 2.210000000000001,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 32.39,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 111.46000000000005,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 14.429999999999994,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 12.379999999999997,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 5.519999999999998,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 4.549999999999999,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 21.88,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 33.040000000000006,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 3.3499999999999988,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 1.6300000000000001,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 1.7500000000000004,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.03,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.06,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0.03,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0.05,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.08,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0.95,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 1.1700000000000002,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 1.1400000000000001,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.6900000000000001,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 7.460000000000001,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0.05,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "KENTUCKY"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 260.33,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 88.78999999999999,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 86.28999999999996,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 11.470000000000002,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 67.43999999999998,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 42.769999999999996,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 220.96000000000006,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 117.22,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 57.670000000000016,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 20.709999999999987,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 44.77,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 157.02999999999992,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 47.78,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 35.00999999999996,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 123.74000000000007,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 106.44000000000004,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 104,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 41.14999999999997,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 126.32000000000004,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 49.95999999999998,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 57.629999999999995,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 51.61999999999999,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 28.57,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 78.73000000000002,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 23.96999999999999,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 155.88999999999993,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 104.95999999999992,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 5.660000000000002,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 69.63999999999997,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 34.640000000000015,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 9.049999999999995,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 2.0800000000000005,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 7.46,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 1.2300000000000004,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 6.8999999999999995,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 4.260000000000002,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 3.44,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 3.849999999999998,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 3.0199999999999996,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 4.460000000000001,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 0.79,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 3.4599999999999995,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 8.34,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 42.19,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 3.2599999999999976,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 2.3699999999999988,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 0.3800000000000001,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 0.09,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 7.76,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 2.2,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 21.250000000000004,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 6.199999999999997,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 0.43,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.1,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.34,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.09000000000000001,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0.18,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0.9500000000000002,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.08,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 2.79,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 0,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0.02,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.02,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0.42,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0.02,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "LOUISIANA"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 401.96,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 719.1699999999997,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 198.88,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 434.35,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 1086.2799999999993,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 13.389999999999993,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 78.02,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 857.7600000000001,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 891.8900000000002,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 134.35,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 509.67,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 271.0900000000001,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 837.7399999999998,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 557.6999999999999,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 540.6100000000001,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 297.99000000000007,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 611.07,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 61.28999999999999,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 578.0000000000001,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 504.5800000000002,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 335.01,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 1108.8700000000001,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 106.14999999999996,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 193.05000000000004,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 987.72,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 181.54999999999998,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 626.7500000000001,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 710.4800000000001,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 115.38999999999997,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 478.88000000000005,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 462.59,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 270.41,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 413.0500000000002,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 279.0799999999999,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 718.01,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 48.489999999999995,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 373.9099999999999,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 295.75000000000006,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 29.700000000000003,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 24.63,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 3.5100000000000002,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 0.7999999999999999,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 41.48,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 120.26999999999995,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 20.980000000000018,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 5.319999999999999,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 3.4399999999999986,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 1.44,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 0.8999999999999999,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 15.909999999999997,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 117.78,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 1.8900000000000001,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 4.22,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.44999999999999996,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 1.26,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0.25,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0.66,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 0,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 0.32,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.56,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.24,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0.16,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.24,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.32,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "MAINE"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 1089.3899999999992,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 126.04000000000005,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 73.89,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 1264.8499999999995,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 65.17000000000002,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 41.18,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 1575.9099999999999,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 133.17000000000002,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 405.28000000000003,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 698.1699999999996,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 159.06000000000006,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 852.9199999999997,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 233.84000000000015,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 384.3299999999998,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 535.19,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 196.78,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 613.7800000000002,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 87.39999999999995,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 488.4300000000002,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 50.880000000000024,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 435.36999999999995,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 740.2699999999998,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 61.719999999999985,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 269.06999999999994,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 348.0399999999999,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 79.45999999999998,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 433.86,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 83.50999999999999,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 310.7899999999999,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 79.68,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 210.82999999999993,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 76.08000000000001,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 104.47999999999996,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 130.28,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 96.62000000000005,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 60.08000000000001,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 89.51000000000005,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 35.52,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 57.76999999999998,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 4.859999999999999,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 2.7499999999999996,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 2.6,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 34.61000000000001,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 13.599999999999998,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 0.27,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 0.32000000000000006,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 0.5700000000000001,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 1.5399999999999998,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 19.900000000000002,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 8.48,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 1.23,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 0.38,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 1.9800000000000002,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.11,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.1,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.16999999999999998,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0.3,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 2.53,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.7600000000000002,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0.22,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0.3,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 2.4800000000000004,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 4.239999999999998,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 3.6600000000000006,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.21999999999999997,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0.02,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.1,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.08,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.5,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0.06,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "MARYLAND"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 981.0599999999996,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 351.4200000000001,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 630.29,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 386.78,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 463.19,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 351.86000000000007,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 1039.49,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 286.73,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 613.81,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 478.32000000000005,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 229.97,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 546.1899999999999,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 498.7200000000001,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 474.01000000000005,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 564.8900000000001,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 752.1699999999997,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 433.3800000000001,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 186.65999999999994,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 798.36,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 252.7,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 674.9999999999999,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 556.88,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 264.71999999999997,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 311.53999999999985,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 940.07,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 68.28000000000002,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 475.05000000000007,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 957.5000000000001,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 72.00000000000001,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 222.04999999999998,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 714.96,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 123.21999999999997,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 420.5799999999999,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 416.44000000000005,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 511.33,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 84.1,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 135.92000000000002,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 354.48999999999984,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 15.019999999999998,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 7.4700000000000015,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 9.839999999999996,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 6.589999999999997,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 15.750000000000002,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 8.069999999999999,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 21.959999999999997,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 69.11999999999998,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 7.079999999999998,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 2.69,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 0.74,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 12.299999999999999,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 5.450000000000001,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 0.49,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 0.9800000000000004,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 1.05,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.1,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.15000000000000002,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 1.46,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 1.3700000000000003,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.6300000000000001,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 1.09,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0.09000000000000001,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 1.79,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 0.5400000000000001,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.7200000000000001,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.35,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0.31000000000000005,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.12000000000000001,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0.08,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.2,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.8800000000000001,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0.02,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0.04,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "MASSACHUSETTS"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 547.5499999999998,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 376.45999999999987,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 583.6200000000001,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 133.47999999999996,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 881.09,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 462.1399999999998,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 132.48000000000002,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 1600.8799999999999,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 47.72000000000002,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 115.59000000000002,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 1505.4999999999995,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 328.17,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 299.7,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 1119.5000000000007,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 168.34999999999994,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 765.18,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 466.94000000000005,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 121.23999999999998,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 627.9300000000001,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 148.06,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 561.0699999999998,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 312.10000000000014,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 575.29,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 221.85000000000005,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 407.49,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 322.98,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 568.61,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 309.13000000000005,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 540.1400000000001,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 234.85000000000008,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 530.3800000000001,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 147.69,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 451.59000000000003,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 349.4100000000001,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 318.94999999999993,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 516.6499999999999,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 354.48,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 336.97999999999996,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 176.04,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 13.300000000000006,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 4.0299999999999985,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 4.459999999999999,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 20.279999999999998,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 28.89000000000001,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 25.720000000000002,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 46.65000000000002,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 25.06,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 35.269999999999996,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 65.63999999999996,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 13.5,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 82.22,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 9.429999999999996,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 3.0199999999999974,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.3500000000000001,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.6000000000000001,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.03,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 3.3000000000000003,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0.7500000000000001,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 1.1600000000000001,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0.30000000000000004,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0.32000000000000006,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 4.229999999999999,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 4.039999999999999,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.36000000000000004,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.13999999999999999,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0.07,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.15000000000000002,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0.04,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.02,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.08,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0.09000000000000001,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0.02,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "MICHIGAN"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 79.13000000000001,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 492.36000000000007,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 218.99000000000012,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 123.53000000000002,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 95.10999999999999,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 752.33,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 313.59999999999997,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 1062.0000000000002,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 283.0300000000001,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 25.11999999999999,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 256.19999999999993,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 655.68,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 300.30999999999995,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 35.339999999999996,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 567.7300000000001,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 398.00999999999993,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 770.5299999999999,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 62.95999999999998,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 44.78999999999999,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 319.35,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 286.2999999999999,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 114.47,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 125.16,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 93.36,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 96.97999999999999,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 136.2199999999999,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 92.93,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 225.26999999999998,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 40.74,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 229.33000000000004,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 37.830000000000034,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 80.06000000000002,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 126.30000000000004,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 20.60000000000001,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 47.43000000000001,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 76.78000000000002,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 9.729999999999993,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 26.45999999999999,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 46.56000000000001,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 3.7599999999999985,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 0.5200000000000001,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 0.7500000000000002,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 1.2900000000000003,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 2.06,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 0.7300000000000002,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 0.6500000000000001,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 2.209999999999999,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 5.83,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 10.830000000000005,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 68.05999999999999,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 2.09,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 29.849999999999994,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 26.869999999999997,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.17,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 1.08,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.8400000000000001,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0.6500000000000001,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0.48000000000000004,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 0.16,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 9.21,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.63,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.2,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.37000000000000005,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.35,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0.02,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0.04,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "MINNESOTA"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 14.960000000000004,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 58.260000000000026,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 106.73999999999998,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 99.49000000000004,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 91.25000000000003,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 64.61999999999998,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 115.45999999999995,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 145.94,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 72.75,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 107.81000000000003,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 61.44999999999999,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 67.5,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 66.43000000000002,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 76.35,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 68.90000000000002,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 119.04000000000006,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 29.84999999999999,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 261.4599999999999,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 51.15000000000003,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 56.99000000000001,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 30.33999999999998,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 10.910000000000004,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 1.1000000000000005,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 6.07,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 66.8,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 9.049999999999995,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 2.7100000000000004,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 0.61,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 1.4700000000000002,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 0.7300000000000002,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 2.08,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 31.209999999999994,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 1.08,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 3.91,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.16,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.08,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0.04,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.4,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0.16,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 1.27,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 0.04,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 0.5,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.04,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.14,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "MISSISSIPPI"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 198.6300000000001,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 183.46000000000015,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 149.81000000000003,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 369.76999999999987,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 43.15999999999999,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 152.96000000000012,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 539.4799999999998,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 345.1900000000001,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 17.37,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 186.45,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 525.47,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 76.60999999999997,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 15.55,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 175.17000000000007,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 178.7100000000001,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 196.0800000000001,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 155.96,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 30.220000000000006,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 166.93000000000012,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 33.55,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 150.17000000000007,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 203.80000000000007,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 58.019999999999996,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 188.52999999999997,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 60.98999999999998,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 218.84000000000012,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 37.87999999999999,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 96.51999999999997,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 124.87999999999998,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 102.19999999999999,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 82.41,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 84.70999999999995,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 17.349999999999998,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 102.08999999999996,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 31.73000000000001,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 64.05,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 24.259999999999998,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 60.20000000000002,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 12.539999999999994,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 7.469999999999996,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 0.6900000000000001,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 1.5700000000000003,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 16.45,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 42.81000000000003,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 3.7000000000000006,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 1.1500000000000001,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 5.489999999999997,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 5.409999999999997,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 4.8,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 18.569999999999993,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 3.5300000000000002,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 9.719999999999995,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 1,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.02,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.04,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.04,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0.12,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0.02,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.62,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 3.7600000000000007,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0.41000000000000003,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 9.969999999999999,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 1.04,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.02,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.8099999999999999,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.04,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.06,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0.02,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0.02,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0.02,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "MISSOURI"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 139.85999999999999,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 817.7600000000001,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 117.52000000000001,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 284.84999999999997,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 1007.9700000000001,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 419.5700000000001,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 355.9200000000001,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 1422.5700000000008,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 81.57000000000005,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 111.71000000000004,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 1119.7600000000002,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 1973.32,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 476.48000000000025,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 161.21,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 588.4800000000002,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 1122.0600000000002,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 720.7899999999998,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 175.29,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 422.64999999999986,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 843.3600000000001,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 341.6000000000001,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 676.1200000000001,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 300.15,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 416.61999999999995,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 643.9200000000001,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 505.27000000000004,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 749.9799999999998,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 449.8199999999999,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 1016.6099999999997,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 528.6399999999999,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 1065.4399999999996,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 625.59,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 313.9900000000001,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 326.15,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 1181.3600000000001,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 482.41,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 579.5900000000001,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 556.3699999999999,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 272.68999999999994,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 48.96,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 9.690000000000003,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 17.130000000000003,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 16.009999999999998,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 112.98000000000002,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 2.3499999999999996,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 48.63,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 46.20000000000001,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 6.979999999999999,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 65.89000000000001,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 119.64999999999999,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 13.860000000000003,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 7.869999999999999,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 0.26,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 20.52,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.24,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 17.11,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 9.66,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 1.63,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 0,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "MONTANA"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 78.95,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 303.0299999999999,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 745.32,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 24.91,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 31.60999999999999,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 117.35000000000001,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 331.03,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 639.7000000000004,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 86.34000000000002,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 34.45999999999999,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 209.0600000000001,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 276.00999999999976,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 129.04000000000002,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 34.6,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 428.55,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 401.02,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 186.1300000000001,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 71.56999999999998,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 395.65000000000026,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 37.400000000000006,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 263.28000000000014,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 207.9900000000001,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 275.31999999999977,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 41.749999999999986,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 214.03,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 183.75000000000014,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 191.60000000000002,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 12.07,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 178.58,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 16.79,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 108.78999999999999,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 29.320000000000004,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 14.810000000000004,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 44.18999999999998,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 8.13,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 15.859999999999998,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 54.63000000000001,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 31.990000000000002,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 11.640000000000004,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 36.53000000000001,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 4.59,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 44.87000000000001,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 52.320000000000014,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 4.880000000000002,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 1.6100000000000003,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 0.37,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 6.08,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 25.54,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 3.5199999999999996,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 13.69,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 0.51,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 4.26,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 4.93,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.25,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.19,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 6.65,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 5,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.06,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "NEBRASKA"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 275.84000000000003,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 811.6899999999997,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 397.32,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 244.43000000000004,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 71.80000000000001,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 125.90000000000002,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 18.450000000000003,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 38.120000000000005,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 60.53,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 67.89999999999999,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 171.47999999999993,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 285.3100000000001,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 102.30000000000004,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 182.19,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 165.36999999999995,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 55.2,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 592.3099999999997,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 73.59999999999998,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 220.09000000000003,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 262.89000000000004,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 197.7399999999999,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 191.46999999999994,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 67.74,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 233.76999999999992,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 50.709999999999994,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 14.34,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 59.9,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 1.74,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 0.21,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 4.03,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 1.28,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 0.18,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 0.17,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 26.76,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 4.300000000000001,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 12.400000000000002,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 10.870000000000003,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 2.5999999999999996,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 2.6100000000000003,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 1.4300000000000002,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 1.58,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.22,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.30000000000000004,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0.19,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 0.99,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 17.709999999999997,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 1.4700000000000002,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.07,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0.07,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0.06,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.24,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.06,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0.35,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "NEVADA"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 272.15000000000003,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 344.5299999999998,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 126.38000000000004,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 299.1499999999999,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 151.26,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 218.48000000000002,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 846.7,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 55.13000000000002,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 185.39000000000001,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 393.1299999999999,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 341.34,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 133.98999999999998,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 147.66000000000005,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 201.98000000000002,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 167.14000000000001,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 211.1800000000001,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 126.00999999999993,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 33.89999999999999,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 226.70999999999995,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 61.040000000000006,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 77.53999999999999,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 230.59999999999997,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 34.400000000000006,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 196.43999999999988,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 447.27,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 50.70999999999997,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 168.21,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 831.4399999999999,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 35.34,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 69.00999999999999,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 368.01,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 76.52000000000002,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 186.35999999999996,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 234.64000000000004,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 163.61999999999998,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 6.440000000000001,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 134.65000000000003,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 55.02999999999999,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 11.590000000000002,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 3.8600000000000008,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 21.01,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 27.100000000000012,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 8.4,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 26.65,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 98.96000000000002,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 90.34,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 20.26000000000001,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 2.3900000000000006,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 1.1300000000000001,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 29.049999999999997,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 7.15,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 3.18,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 26.690000000000005,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.98,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.5,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 3.3000000000000003,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 2.6199999999999997,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 16.240000000000002,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 10.23,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 1.4400000000000002,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 0,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 1.44,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0.18,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 1.93,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0.24,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "NEW HAMPSHIRE"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 797.1400000000001,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 181.85999999999993,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 602.8700000000001,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 494.1899999999997,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 373.96000000000004,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 726.94,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 359.92,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 792.9099999999997,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 215.06,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 1108.94,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 716.9799999999999,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 104.83000000000001,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 301.9899999999999,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 1044.5400000000002,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 322.09999999999997,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 927.1399999999998,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 658.6599999999995,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 78.87,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 1151.7500000000002,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 250.71000000000004,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 715.4500000000002,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 705.0799999999999,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 601.6799999999998,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 395.01000000000005,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 1282.7000000000003,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 81.21000000000004,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 445.79000000000013,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 937.1000000000001,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 340.37,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 458.10000000000014,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 429.0799999999999,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 502.2099999999999,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 175.27000000000004,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 293.5899999999998,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 510.19000000000005,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 160.61999999999998,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 176.38000000000005,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 61.18000000000003,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 29.390000000000008,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 8.799999999999999,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 9.739999999999997,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 13.46,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 23.46000000000001,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 17.389999999999997,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 5.640000000000002,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 10.1,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 75.03000000000002,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 6.479999999999998,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 8.559999999999997,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 2.6699999999999995,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 1.0100000000000002,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 0.6600000000000001,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 8.919999999999998,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.7700000000000004,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.07999999999999999,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.36,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0.07,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0.31000000000000005,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 11.6,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0.5,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 4.25,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 5.279999999999999,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 2.4699999999999998,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 13.049999999999997,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.4,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0.060000000000000005,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 1.68,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0.04,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.02,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0.08,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0.01,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "NEW JERSEY"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 663.4100000000003,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 54.780000000000015,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 529.2299999999999,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 324.5700000000001,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 271.9000000000001,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 148.80000000000004,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 731.9000000000003,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 147.97000000000003,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 234.9399999999999,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 487.2699999999998,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 628.8900000000001,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 316.10000000000014,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 216.6299999999999,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 778.1000000000004,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 315.63999999999993,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 105.71000000000002,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 303.7299999999999,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 67.89999999999999,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 215.40999999999997,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 226.77999999999997,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 174.64000000000001,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 671.4399999999997,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 136.02000000000004,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 297.51,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 210.63,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 662.89,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 355.99000000000007,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 621.7499999999998,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 495.3200000000001,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 747.3299999999996,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 912.1699999999995,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 484.0300000000001,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 6.81,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 2.07,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 0,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 0,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 111.14999999999999,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 68.59000000000002,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 126.32,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 61.20000000000004,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 17.64,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 28.299999999999986,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 28.590000000000007,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 37.27000000000002,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 12.069999999999993,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 14.029999999999994,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 5.35,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 9.07,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 1.3000000000000003,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 1.9200000000000002,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 0,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 3.1500000000000004,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 0.99,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 1.1,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 5.09,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0.28,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 2.6000000000000005,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 10.550000000000004,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 1.4000000000000001,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 6.660000000000001,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 4.919999999999999,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.06,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 1.8200000000000003,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.96,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.4,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "NEW MEXICO"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 649.9699999999998,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 249.08999999999997,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 315.3899999999999,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 423.22,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 465.05999999999995,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 549,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 258.13,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 516.4300000000001,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 477.4799999999998,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 202.81000000000003,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 518.8399999999999,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 331.36,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 212.22999999999996,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 789.51,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 191.24,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 478.18,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 334.85,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 52.41000000000001,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 600.8199999999998,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 107.99999999999999,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 330.9099999999999,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 353.09,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 201.32999999999996,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 240.62999999999994,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 500.59000000000015,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 74.13999999999997,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 548.3700000000001,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 241.44000000000003,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 308.53000000000003,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 233.62999999999997,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 364.1499999999999,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 140.21,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 277.27000000000004,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 207.28999999999996,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 272.9999999999999,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 107.71000000000001,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 156.92000000000002,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 52.36999999999999,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 61.059999999999995,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 6.680000000000001,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 21.07,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 30.47999999999999,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 8.569999999999997,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 23.920000000000005,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 3.61,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 9.789999999999994,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 7.829999999999997,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 6.83,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 17.38,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 26.19,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 10.439999999999998,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 8.939999999999996,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 11.009999999999993,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 1.9700000000000009,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 1.0900000000000003,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.21000000000000005,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0.8400000000000003,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0.9200000000000004,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 5.3100000000000005,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 2.4699999999999984,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0.54,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 1.6300000000000003,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 4.479999999999999,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 7.799999999999996,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.62,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.34,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0.02,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.13999999999999999,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0.02,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0.01,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "NEW YORK"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 1823.69,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 38.49000000000002,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 41.17,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 480.4800000000001,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 423.03999999999996,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 495.5900000000001,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 1685.3399999999995,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 323.86999999999983,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 40.30000000000002,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 226.07,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 1383.3700000000003,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 664.5000000000001,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 210.26999999999992,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 658.4000000000002,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 564.8599999999999,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 165.96000000000004,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 671.48,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 72.50000000000001,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 225.15999999999994,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 127.62999999999995,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 26.97,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 442.45999999999987,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 118.86999999999996,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 81.36999999999998,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 93.5,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 115.47000000000001,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 229.32,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 29.680000000000003,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 178.79999999999995,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 43.639999999999986,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 93.72999999999996,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 73.11999999999999,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 27.059999999999995,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 110.69999999999999,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 19.269999999999996,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 30.529999999999994,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 26.31999999999999,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 8.589999999999996,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 15.879999999999994,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 19.029999999999987,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 6.479999999999996,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 7.459999999999997,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 19.47,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 35.890000000000015,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 0.7100000000000002,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 0.12,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 0.12000000000000001,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 0.06,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 0.35000000000000003,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 0.9300000000000003,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 2.15,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 1.9700000000000006,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 2.21,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.1,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.04,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0.14,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.07,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0.23,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0.03,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 2.9899999999999993,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 0.71,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.6400000000000001,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.36000000000000004,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.04,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.05,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.02,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "NORTH CAROLINA"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 55.73,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 339.19,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 117.00000000000001,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 142.06,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 318.07000000000005,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 373.6400000000001,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 657.6300000000001,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 290.44999999999993,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 16.520000000000007,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 8.4,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 863.4500000000002,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 843.2099999999996,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 149.05000000000007,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 223.20000000000002,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 274.07999999999987,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 798.5300000000001,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 644.3599999999998,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 64.10999999999997,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 40.84,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 236.08,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 214.45000000000005,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 245.94999999999996,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 63.619999999999976,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 426.9800000000001,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 432.13999999999993,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 254.43000000000004,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 454.18000000000006,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 407.81000000000006,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 362.47000000000014,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 629.25,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 714.58,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 899.5399999999998,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 390.5599999999999,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 438.99999999999994,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 583.2199999999999,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 677.9800000000002,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 813.2300000000001,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 623.2599999999999,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 212.6400000000001,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 143.15999999999994,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 22.83000000000001,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 13.030000000000001,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 51.24999999999997,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 36.16999999999999,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 9.490000000000002,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 11.220000000000004,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 5.82,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 131.87000000000006,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 0.45999999999999996,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 4.74,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 27.43999999999999,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 2.6,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 0,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0.15,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 3.1699999999999995,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 0,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 0,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.15,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "NORTH DAKOTA"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 355.92,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 561.14,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 277.6000000000001,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 291.3200000000001,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 539.34,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 233.67000000000004,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 410.4999999999999,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 544.79,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 136.53000000000003,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 366.37,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 694.2700000000001,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 74.00000000000003,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 22.400000000000002,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 1132.7699999999995,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 127.08,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 276.40999999999997,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 557.9300000000002,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 49.82000000000001,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 200.42999999999995,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 239.44999999999996,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 282.31999999999994,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 268.2900000000001,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 161.8400000000001,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 295.7600000000002,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 248.00000000000006,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 314.96000000000004,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 322.2899999999999,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 170.30999999999997,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 477.2900000000002,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 86.93999999999998,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 312.7799999999999,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 124.38999999999999,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 191.14999999999995,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 208.73,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 118.46000000000004,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 146.63000000000002,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 191.15,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 90.95999999999997,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 63.04000000000001,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 11.73999999999999,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 3.2499999999999982,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 5.379999999999998,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 37.69999999999999,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 37.07,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 2.819999999999998,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 3.769999999999998,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 27.44000000000001,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 1.1,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 6.759999999999999,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 17.290000000000003,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 4.67,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 3.02,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 3.5399999999999996,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.2,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.03,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.8300000000000001,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0.09999999999999998,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0.01,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0.8799999999999999,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 25.089999999999996,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 5.219999999999999,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.11000000000000001,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.05,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0.11,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.04,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0.02,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.060000000000000005,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.3,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0.03,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0.01,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "OHIO"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 268.70999999999964,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 46.190000000000005,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 164.92999999999995,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 32.169999999999995,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 43.169999999999995,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 101.87,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 378.08000000000027,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 102.91000000000001,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 15.219999999999995,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 45.62000000000001,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 116.62000000000003,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 194.43999999999997,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 60.40000000000005,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 88.77999999999999,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 260.91999999999996,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 76.06000000000004,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 166.8,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 51.13,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 188.96999999999997,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 10.790000000000006,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 66.02000000000001,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 354.07000000000005,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 27.429999999999993,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 359.93999999999977,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 92.03,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 173.09,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 152.17999999999998,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 132.27,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 440.4500000000002,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 66.1,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 317.88,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 29.150000000000002,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 51.72,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 25.069999999999997,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 86.46000000000001,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 14.169999999999993,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 42.409999999999975,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 9.969999999999994,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 25.249999999999993,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 32.349999999999994,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 4.960000000000001,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 5.630000000000002,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 30.63,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 25.059999999999985,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 0.49999999999999994,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 2.4600000000000004,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 1.1,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 9.64,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 9.989999999999998,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 1.7200000000000006,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 0.9100000000000003,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 0.85,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 22.660000000000007,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.24,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.99,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.03,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0.27,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.99,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0.12,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0.25,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 4.029999999999999,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 5.6,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.25,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "OKLAHOMA"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 223.08999999999995,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 492.32000000000005,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 276.3599999999999,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 242.56000000000003,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 514.2,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 230.36999999999998,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 193.5,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 705.4300000000001,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 919.1500000000002,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 38.190000000000005,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 121.89,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 219.8,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 671.1199999999999,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 607.5099999999999,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 499.14000000000004,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 693.95,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 239.87000000000006,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 156.32000000000002,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 453.3700000000001,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 71.91000000000001,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 367.59999999999997,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 684.3799999999999,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 49.38000000000001,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 617.84,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 209.72999999999985,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 558.1400000000001,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 244.3700000000001,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 295.1600000000001,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 135.01999999999995,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 879.25,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 529.02,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 447.57000000000005,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 624.9399999999997,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 322.05,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 766.2300000000001,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 258.3,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 453.01000000000005,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 181.74000000000004,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 126.90999999999993,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 86.72,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 30.700000000000003,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 9.830000000000005,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 21.150000000000006,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 15.970000000000006,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 8.950000000000001,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 19.52,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 1.03,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 8.429999999999998,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 7.120000000000002,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 12.769999999999994,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 20.58,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 2.78,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 0.08,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.2,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.7200000000000001,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.4,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0.19000000000000003,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.26,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 3.01,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 1.3000000000000003,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 1.45,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 1.3500000000000003,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 2.78,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.29000000000000004,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0.09,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.32999999999999996,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.09,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0.15,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0.18,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "OREGON"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 583.9500000000002,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 489.5599999999998,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 356.56,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 821.6000000000003,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 470.6900000000001,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 336.3800000000001,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 848.1100000000004,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 917.3599999999999,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 243.53000000000003,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 390.89,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 1329.75,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 186.56999999999996,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 148.62,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 1011.3199999999999,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 380.4199999999999,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 563.08,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 256.55999999999995,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 127.30999999999999,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 611.47,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 113.40999999999998,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 306.69000000000005,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 483.95999999999975,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 165.43999999999997,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 299.8599999999999,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 358.49999999999994,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 146.17999999999995,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 351.84,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 170.43,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 397.9499999999998,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 117.09,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 307.17999999999995,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 247.52000000000004,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 59.7,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 226.10999999999999,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 83.07999999999998,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 106.12999999999998,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 101.85,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 57.21,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 47.15999999999999,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 6.81,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 2.5400000000000005,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 10.659999999999998,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 17.65,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 15.629999999999994,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 0.6100000000000002,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 3.439999999999999,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 7.74,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 4.78,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 28.499999999999996,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 27.090000000000007,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 2.8099999999999983,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 0.5700000000000002,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 9.489999999999998,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 4.33,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.07,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0.04,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0.33,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.24999999999999997,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0.26,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 4.399999999999999,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 2.0000000000000004,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 3.7699999999999987,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 11.719999999999995,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.08,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.07,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0.01,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.09999999999999999,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.12999999999999998,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0.03,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0.05,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "PENNSYLVANIA"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 735.3200000000002,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 270.62,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 39.22999999999999,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 665.0499999999998,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 1472.6900000000007,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 9.360000000000003,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 65.78999999999999,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 994.0499999999998,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 368.6899999999998,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 679.2199999999999,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 35.94999999999999,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 416.8499999999999,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 467.71999999999974,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 57.669999999999995,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 609.2499999999999,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 296.38999999999993,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 535.99,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 55.54000000000003,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 160.60999999999996,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 507.3399999999999,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 48.42999999999999,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 561.6100000000001,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 30.68,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 113.30000000000001,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 665.7800000000002,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 61.969999999999985,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 223.67000000000002,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 657.21,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 22.430000000000003,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 72.66999999999999,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 496.84000000000003,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 35.91999999999997,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 227.84000000000006,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 766.1100000000002,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 378.9700000000001,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 139.60000000000005,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 279.31999999999994,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 444.82000000000005,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 9.750000000000002,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 6.819999999999999,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 7.28,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 2.9000000000000004,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 11.399999999999999,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 24.720000000000006,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 52.25000000000001,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 68.08999999999999,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 6.580000000000001,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 0.54,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 2.23,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 6.760000000000002,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 0.85,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 10.880000000000003,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 0.2,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.2,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0.2,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 3.9000000000000004,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 2.9899999999999998,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.4,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 2.28,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0.1,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.7,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0.49,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.49,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "RHODE ISLAND"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 1138.49,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 12.200000000000003,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 14.450000000000001,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 189.95,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 182.57999999999998,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 360.6400000000001,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 637.6099999999997,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 46.26000000000003,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 48.240000000000016,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 99.17999999999998,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 373.40000000000015,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 60.33999999999998,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 32.32000000000001,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 481.97000000000014,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 218.2299999999999,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 153.6599999999999,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 363.59999999999997,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 78.91000000000001,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 358.19000000000005,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 161.85999999999999,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 120.64999999999999,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 453.0799999999999,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 90.61999999999999,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 34.30999999999998,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 81.69,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 89.38,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 254.90999999999997,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 53.33,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 384.73999999999995,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 248.21999999999994,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 472.1800000000001,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 82.91000000000005,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 53.68000000000003,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 136.62999999999997,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 38.39999999999998,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 95.74999999999999,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 161.62000000000006,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 50.54999999999998,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 26.30999999999998,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 20.439999999999994,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 1.52,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 5.3400000000000025,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 24.009999999999987,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 32.76999999999999,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 7.630000000000002,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 2.8600000000000008,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 1.9600000000000009,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 0.5700000000000001,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 0.15,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 3.279999999999998,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 6.440000000000001,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 3.35,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 5.019999999999999,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0.03,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 7.540000000000001,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0.06,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 0.52,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 0.12,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.37,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.8,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.05,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "SOUTH CAROLINA"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 160.16000000000003,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 167.76999999999992,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 346.3100000000002,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 212.3599999999999,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 96.37000000000008,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 299.08,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 1373.9400000000005,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 167.25000000000003,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 33.59999999999999,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 9.840000000000003,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 212.45999999999998,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 1173.7800000000002,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 253.82999999999996,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 61.33999999999997,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 143.09000000000003,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 507.31,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 258.73000000000013,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 100.62999999999998,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 189.6899999999999,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 218.29999999999998,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 140.26000000000005,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 157.38999999999993,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 102.59000000000003,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 106.72000000000001,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 115.25999999999998,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 68.80999999999999,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 123.53000000000004,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 63.58999999999998,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 86.75,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 81.49000000000002,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 18.410000000000004,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 129.12000000000003,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 17.589999999999996,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 21.72,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 64.25000000000003,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 12.530000000000001,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 9.86,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 16.730000000000004,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 5.87,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 8.670000000000002,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 0.6,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 7.640000000000001,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 15.790000000000006,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 31.34,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 1.7799999999999998,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 0.43999999999999995,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 4.12,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 51.879999999999995,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 0.74,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 10.620000000000001,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 0.28,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 2.29,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 1.2000000000000002,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "SOUTH DAKOTA"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 315.43,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 33.03999999999999,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 179.91000000000008,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 134.79000000000005,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 68.9900000000001,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 133.48,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 647.85,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 51.309999999999995,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 50.179999999999986,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 106.41000000000004,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 403.6499999999999,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 108.42999999999992,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 95.17000000000003,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 278.13,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 106.34,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 194.95,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 184.3799999999999,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 65.79999999999997,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 150.46999999999989,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 60.99999999999999,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 127.54000000000002,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 252.76,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 104.09999999999997,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 80.63999999999999,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 200.47999999999993,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 84.72999999999998,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 416.4,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 172.06999999999994,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 617.0000000000001,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 455.99,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 793.5500000000002,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 275.98,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 535.8999999999999,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 403.0999999999999,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 666.3199999999999,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 183.54999999999995,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 629.4300000000002,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 238.12000000000006,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 332.7399999999999,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 53.620000000000005,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 1.7300000000000004,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 0.53,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 13.529999999999998,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 24.689999999999998,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 4.659999999999998,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 3.8999999999999995,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 1.29,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 4.089999999999998,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 4.799999999999999,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 15.749999999999993,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 22.259999999999998,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 1.7300000000000006,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 3.83,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.08,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.12000000000000001,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.02,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 1.2000000000000002,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0.02,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 2.85,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 1.93,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.2,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.53,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.04,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.05,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "TENNESSEE"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 97.35000000000002,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 71.27999999999997,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 73.12,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 39.56,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 76.58,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 361.3999999999999,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 490.6600000000001,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 64.06999999999998,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 125.57999999999998,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 235.14,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 95.33999999999995,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 115.97999999999999,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 249.87999999999997,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 308.34,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 517.23,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 233.4200000000001,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 542.2,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 188.8599999999999,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 410.13000000000005,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 109.48,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 583.88,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 749.4799999999998,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 175.6499999999999,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 808.7800000000002,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 283.26,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 885.8199999999999,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 906.1199999999999,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 455.73,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 755.2400000000002,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 471.87000000000006,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 889.5300000000003,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 360.65000000000003,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 516.1899999999998,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 164.07000000000002,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 665.6100000000005,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 164.36,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 383.1799999999998,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 284.3199999999998,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 239.95,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 125.32000000000001,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 47.57999999999998,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 44.86999999999999,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 72.35,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 77.40999999999997,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 13.170000000000002,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 4.059999999999997,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 1.4300000000000008,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 2.2300000000000004,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 2.040000000000001,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 13.989999999999998,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 7.539999999999999,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 4.5399999999999965,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 1.3400000000000005,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 6.0299999999999985,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 1.1500000000000001,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.24000000000000005,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 3.3299999999999987,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 2.5599999999999987,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 2.2700000000000005,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 2.51,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0.09,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 18.430000000000003,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 22.860000000000003,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 1.2300000000000002,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 5.67,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0.060000000000000005,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.09999999999999999,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0.08999999999999998,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.18000000000000005,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.07,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0.01,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "TEXAS"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 16.82999999999999,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 68.89999999999999,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 1044.7900000000009,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 29.720000000000002,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 13.909999999999998,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 402.09999999999997,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 2184.8700000000017,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 50.16,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 117.88999999999997,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 396.78999999999985,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 1808.86,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 1002.2299999999998,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 1363.2199999999996,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 281.0899999999999,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 2589.0599999999995,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 1211.27,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 200.67000000000002,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 746.0999999999999,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 1244.5700000000004,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 99.24000000000002,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 910.9399999999998,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 526.54,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 879.1999999999997,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 331.40000000000003,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 652.5100000000001,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 775.41,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 1043.8600000000008,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 101.05000000000001,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 284.17,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 1749.89,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 458.83000000000004,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 670.8899999999998,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 551.7699999999996,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 179.59999999999994,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 430.5699999999999,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 316.23000000000013,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 260.75000000000006,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 444.8600000000001,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 68.2,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 37.81000000000002,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 2.04,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 1.09,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 3.52,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 30.040000000000003,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 13.709999999999996,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 10.74,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 1.2100000000000002,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 27.849999999999998,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 166.51000000000016,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 1.7499999999999998,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 3.2399999999999998,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 1.5200000000000002,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 2.979999999999999,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.19,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.61,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 1.6900000000000004,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.78,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 6.9,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 8.5,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 12.360000000000001,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 7.799999999999999,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 5.77,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.05,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0.1,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0.13,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "UTAH"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 334.7999999999998,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 105.31000000000003,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 236.69000000000003,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 318.4,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 1146.08,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 312.58000000000004,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 380.65999999999974,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 389.3000000000002,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 2974.790000000002,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 289.31,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 1652.6399999999999,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 1029.1899999999998,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 241.07000000000002,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 384.64000000000004,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 1071.2900000000004,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 2323.7299999999996,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 751.4600000000002,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 179.95999999999998,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 858.63,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 1348.8300000000002,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 407.12,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 1711.3699999999997,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 157.47000000000006,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 1130.93,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 1397.3200000000002,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 148.93,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 760.2099999999999,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 1894.9400000000007,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 340.86000000000007,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 761.4599999999996,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 549.1999999999999,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 525.5899999999998,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 893.3199999999999,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 295.8799999999999,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 518.32,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 405.7999999999998,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 596.7699999999999,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 360.66,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 79.16,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 9.960000000000003,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 1.8499999999999999,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 0.6900000000000001,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 1.98,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 26.59999999999999,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 17.07,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 25.570000000000014,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 11.88,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 15.280000000000001,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 34.37,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 47.16,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 10.52,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 23.31,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 41.88,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.38,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.38,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0.76,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 3.9900000000000007,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 0.18,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 0,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.71,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 5.3599999999999985,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.17,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.17,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 9.88,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0.16,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0.16,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "VERMONT"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 0,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 0,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 0,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 0,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 53.4,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 351.88000000000005,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 1158.76,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 727.3500000000001,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 127.82999999999996,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 337.39000000000004,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 475.81000000000006,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 394.23999999999995,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 203.84000000000003,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 1035.2799999999997,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 177.58999999999992,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 341.34000000000003,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 475.4199999999998,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 64.45,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 385.83,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 242.18000000000004,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 191.30000000000004,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 649.31,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 85.42,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 408.71,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 376.52,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 138.95999999999992,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 673.5600000000001,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 120.10000000000004,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 634.53,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 128.67,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 550.1500000000001,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 349.29,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 185.59999999999997,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 285.94999999999993,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 231.09000000000003,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 172.44999999999996,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 274.81,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 93.32000000000005,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 50.58000000000002,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 51.99000000000003,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 9.489999999999998,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 20.259999999999998,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 51.910000000000004,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 32.370000000000005,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 1.5400000000000005,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 8.739999999999991,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 0.8600000000000002,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 0.8500000000000001,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 16.49,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 50.79000000000001,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 49.89000000000001,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 6.009999999999997,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 6.569999999999998,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.24,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.15000000000000002,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.37,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0.07,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 0.4700000000000001,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.8500000000000002,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0.02,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 3.48,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 0.42000000000000004,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 1.22,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.36000000000000004,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.24999999999999997,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.04,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.01,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.03,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0.25,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0.03,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0.01,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "VIRGINIA"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 344.82,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 248.60000000000002,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 631.64,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 197.42999999999992,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 631.9300000000002,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 155.83999999999995,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 473.8400000000002,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 525.47,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 463.74000000000007,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 103.34000000000003,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 112.22999999999999,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 1158.1599999999999,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 919.5900000000001,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 118.23000000000005,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 645.6399999999999,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 765.0699999999999,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 264.04,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 291.67999999999995,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 513.61,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 63.82000000000004,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 482.2900000000001,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 551.1999999999999,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 142.61,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 733.3199999999997,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 243.78,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 473.15000000000003,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 857.4700000000004,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 425.03000000000003,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 481.30000000000007,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 614.3699999999999,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 384.17999999999995,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 512.4699999999999,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 456.1999999999999,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 301.32,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 704.0700000000002,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 166.94,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 674.6899999999999,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 255.7,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 166.67,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 178.8999999999999,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 18.249999999999986,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 1.6800000000000004,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 19.71,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 33.15000000000001,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 28.37,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 25.030000000000005,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 2.22,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 8.14,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 10.259999999999998,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 12.409999999999997,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 10.62,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 25.150000000000002,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 4.049999999999999,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.1,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.8500000000000002,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.7000000000000001,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 3.9099999999999997,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 1.9900000000000004,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 4.709999999999999,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 1.0100000000000002,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0.15,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 1.06,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 6.709999999999999,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 1.5299999999999998,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0.39000000000000007,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.92,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.27,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "WASHINGTON"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 195.98000000000002,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 380.14,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 157.70000000000002,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 291.38,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 599.6500000000001,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 303.34000000000003,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 231.80000000000007,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 605.9,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 63.26,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 110.03999999999996,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 595.16,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 99.06999999999995,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 29.79000000000001,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 592.2399999999999,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 303.7900000000003,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 133.74999999999997,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 497.22000000000025,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 79.63999999999999,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 140.55999999999995,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 143.61999999999998,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 295.53,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 188.45000000000002,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 293.1899999999999,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 227.23999999999998,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 270,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 309.5600000000001,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 512.0100000000001,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 204.22,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 587.09,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 185.11000000000004,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 657.1999999999996,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 406.39000000000004,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 190.38999999999996,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 429.01,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 551.1199999999999,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 696.2900000000001,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 518.6999999999999,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 832.69,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 313.45,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 84.57000000000004,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 20.499999999999996,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 13.819999999999999,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 19.730000000000008,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 31.989999999999995,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 15.510000000000002,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 12.580000000000002,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 12.68000000000001,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 11.730000000000002,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 11.010000000000002,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 13.870000000000001,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 45.54999999999999,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 4.539999999999999,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 1.7500000000000009,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.6,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.1,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0.05,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 2.5100000000000002,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0.11,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0.33,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 2.9499999999999997,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 0.33,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 1.98,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.05,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "WEST VIRGINIA"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 124.61000000000003,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 1016.54,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 748.5800000000002,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 506.57000000000005,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 935.3100000000001,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 317.4799999999999,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 1332.8400000000001,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 1415.3799999999992,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 126.57000000000002,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 66.54999999999998,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 2348.05,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 768.0400000000001,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 636.4500000000004,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 993.0699999999999,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 781.7900000000001,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 1290.5400000000004,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 1407.9099999999999,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 165.52,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 1333.6000000000001,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 383.1399999999999,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 926.1499999999999,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 1171.0699999999997,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 546.7099999999999,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 958.0700000000002,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 1140.8300000000004,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 1166.8400000000001,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 289.5700000000002,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 1389.0500000000002,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 715.7399999999998,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 980.76,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 1665.3700000000001,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 384.7699999999999,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 1090.16,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 932.9300000000002,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 365.34000000000003,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 1413.07,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 370.34999999999985,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 482.21999999999974,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 736.0699999999999,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 49.53000000000001,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 31.89000000000001,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 15.330000000000005,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 31.019999999999985,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 87.53,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 76.33999999999999,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 29.969999999999985,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 13.900000000000002,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 32.03,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 88.54,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 45.35000000000002,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 33.27000000000002,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 13.759999999999998,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 31.289999999999996,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.12,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0.02,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0.6500000000000001,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 1.2000000000000002,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 5.8500000000000005,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 3.0200000000000005,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 6.44,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 13.389999999999995,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.14,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0.04,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.02,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "WISCONSIN"
+         },
+         {
+          "YEAR": 1928,
+          "incidence": 227,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1929,
+          "incidence": 312.15999999999985,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1930,
+          "incidence": 341.54999999999995,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1931,
+          "incidence": 60.689999999999976,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1932,
+          "incidence": 242.10000000000008,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1933,
+          "incidence": 249.06000000000003,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1934,
+          "incidence": 967.4399999999997,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1935,
+          "incidence": 935.4200000000004,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1936,
+          "incidence": 57.52000000000001,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1937,
+          "incidence": 69.90999999999997,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1938,
+          "incidence": 360.59000000000015,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1939,
+          "incidence": 1392.34,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1940,
+          "incidence": 393.6,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1941,
+          "incidence": 381.72999999999985,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1942,
+          "incidence": 635.27,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1943,
+          "incidence": 1088.6099999999997,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1944,
+          "incidence": 728.0799999999998,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1945,
+          "incidence": 157.5799999999999,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1946,
+          "incidence": 397.5900000000001,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1947,
+          "incidence": 170.19,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1948,
+          "incidence": 805.4100000000001,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1949,
+          "incidence": 201.42000000000013,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1950,
+          "incidence": 209.98999999999995,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1951,
+          "incidence": 753.5800000000002,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1952,
+          "incidence": 231.75000000000003,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1953,
+          "incidence": 497.53999999999974,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1954,
+          "incidence": 391.78999999999985,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1955,
+          "incidence": 180.82999999999998,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1956,
+          "incidence": 640.6899999999999,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1957,
+          "incidence": 69.45999999999995,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1958,
+          "incidence": 433.30999999999995,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1959,
+          "incidence": 281.20000000000005,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1960,
+          "incidence": 209.63,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1961,
+          "incidence": 143.65000000000003,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1962,
+          "incidence": 142.93000000000006,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1963,
+          "incidence": 97.92,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1964,
+          "incidence": 84.29000000000003,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1965,
+          "incidence": 226.15000000000015,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1966,
+          "incidence": 72.79,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1967,
+          "incidence": 64.27,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1968,
+          "incidence": 16.999999999999993,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1969,
+          "incidence": 2.43,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1970,
+          "incidence": 3.23,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1971,
+          "incidence": 24.49,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1972,
+          "incidence": 14.399999999999999,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1973,
+          "incidence": 19.68,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1974,
+          "incidence": 4.460000000000001,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1975,
+          "incidence": 0.75,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1976,
+          "incidence": 0.97,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1977,
+          "incidence": 5.770000000000002,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1978,
+          "incidence": 0,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1979,
+          "incidence": 0.43,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1980,
+          "incidence": 0,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1981,
+          "incidence": 0.2,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1982,
+          "incidence": 0,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1983,
+          "incidence": 0,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1984,
+          "incidence": 0,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1985,
+          "incidence": 1.01,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1986,
+          "incidence": 0,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1987,
+          "incidence": 0,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1988,
+          "incidence": 0,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1989,
+          "incidence": 0,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1990,
+          "incidence": 0,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1991,
+          "incidence": 0.65,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1992,
+          "incidence": 0.21,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1993,
+          "incidence": 0,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1994,
+          "incidence": 0,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1995,
+          "incidence": 0,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1996,
+          "incidence": 0.2,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1997,
+          "incidence": 0.61,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1998,
+          "incidence": 0,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 1999,
+          "incidence": 0,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 2000,
+          "incidence": 0,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 2001,
+          "incidence": 0,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 2002,
+          "incidence": 0,
+          "state": "WYOMING"
+         },
+         {
+          "YEAR": 2003,
+          "incidence": 0,
+          "state": "WYOMING"
+         }
+        ]
+       },
+       "layer": [
+        {
+         "encoding": {
+          "detail": {
+           "field": "state",
+           "type": "nominal"
+          },
+          "opacity": {
+           "value": 0
+          },
+          "x": {
+           "axis": {
+            "format": "f",
+            "title": "year"
+           },
+           "field": "YEAR",
+           "scale": {
+            "zero": false
+           },
+           "type": "quantitative"
+          },
+          "y": {
+           "axis": {
+            "title": "measles incidence"
+           },
+           "field": "incidence",
+           "type": "quantitative"
+          }
+         },
+         "height": 300,
+         "mark": "point",
+         "selection": {
+          "selector001": {
+           "empty": "none",
+           "fields": [
+            "state"
+           ],
+           "nearest": true,
+           "on": "mouseover",
+           "resolve": "global",
+           "type": "single"
+          },
+          "selector003": {
+           "bind": "scales",
+           "encodings": [
+            "x"
+           ],
+           "mark": {
+            "fill": "#333",
+            "fillOpacity": 0.125,
+            "stroke": "white"
+           },
+           "on": "[mousedown, window:mouseup] > window:mousemove!",
+           "resolve": "global",
+           "translate": "[mousedown, window:mouseup] > window:mousemove!",
+           "type": "interval",
+           "zoom": "wheel!"
+          }
+         },
+         "width": 800
+        },
+        {
+         "encoding": {
+          "detail": {
+           "field": "state",
+           "type": "nominal"
+          },
+          "opacity": {
+           "condition": {
+            "selection": "selector001",
+            "value": 1
+           },
+           "value": 0.1
+          },
+          "x": {
+           "axis": {
+            "format": "f",
+            "title": "year"
+           },
+           "field": "YEAR",
+           "scale": {
+            "zero": false
+           },
+           "type": "quantitative"
+          },
+          "y": {
+           "axis": {
+            "title": "measles incidence"
+           },
+           "field": "incidence",
+           "type": "quantitative"
+          }
+         },
+         "height": 300,
+         "mark": "line",
+         "width": 800
+        },
+        {
+         "encoding": {
+          "color": {
+           "value": "black"
+          },
+          "x": {
+           "field": "YEAR",
+           "scale": {
+            "zero": false
+           },
+           "type": "quantitative"
+          },
+          "y": {
+           "aggregate": "mean",
+           "field": "incidence",
+           "type": "quantitative"
+          }
+         },
+         "mark": "line"
+        },
+        {
+         "encoding": {
+          "detail": {
+           "field": "state",
+           "type": "nominal"
+          },
+          "opacity": {
+           "condition": {
+            "selection": "selector001",
+            "value": 1
+           },
+           "value": 0
+          },
+          "text": {
+           "field": "state",
+           "type": "nominal"
+          },
+          "x": {
+           "aggregate": "min",
+           "field": "YEAR",
+           "scale": {
+            "domain": {
+             "selection": "selector002"
+            }
+           },
+           "type": "quantitative"
+          },
+          "y": {
+           "aggregate": "mean",
+           "field": "incidence",
+           "type": "quantitative"
+          }
+         },
+         "mark": {
+          "align": "right",
+          "type": "text"
+         }
+        }
+       ]
+      },
+      "text/plain": [
+       "<VegaLite 2 object>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "hover = alt.selection_single(on='mouseover', nearest=True, fields=['state'], empty='none')\n",
+    "brush = alt.selection_interval()\n",
     "\n",
     "line = alt.Chart().mark_line().encode(\n",
     "    alt.X('YEAR:Q',\n",
@@ -39636,7 +59185,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The final plot in the measles notebook wasn't working because it referenced a brush that wasn't defined.

I am not sure I am doing version control right with notebooks. The diffs are huge!